### PR TITLE
Fix for OpenSSL Errors

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,5 @@
+-e .
+
 coverage==3.7.1
 mock==1.0.1
 pre-commit==0.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ grequests==0.2.0
 # Make sure to install the optional security components for requests
 requests[security]==2.7.0
 simplejson==3.6.5
+urllib3==1.10.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ grequests==0.2.0
 # Make sure to install the optional security components for requests
 requests[security]==2.7.0
 simplejson==3.6.5
-urllib3==1.10.4
+

--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,6 @@ setup(
         "requests[security]==2.7.0",
         "grequests==0.2.0",
         "simplejson==3.6.5",
+        "urllib3==1.10.4"
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="threat_intel",
-    version='0.1.3',
+    version='0.1.4',
     provides=['threat_intel'],
     author="Yelp Security",
     url='https://github.com/Yelp/threat_intel',
@@ -17,7 +17,6 @@ setup(
     install_requires=[
         "requests[security]==2.7.0",
         "grequests==0.2.0",
-        "simplejson==3.6.5",
-        "urllib3==1.10.4"
+        "simplejson==3.6.5"
     ],
 )

--- a/threat_intel/__init__.py
+++ b/threat_intel/__init__.py
@@ -25,7 +25,7 @@ OpenDNS Investigate  provides an API that allows querying for:
 
 To use the Investigate API wrapper import InvestigateApi class from threat_intel.opendns module:
 
-    >>> from threat_intel.opendns import InvestigateApi
+    >>> from threat_intel import InvestigateApi
 
 To initialize the API wrapper you need the API key:
 
@@ -195,7 +195,7 @@ VirusTotal provides an API that makes it possible to query for the reports about
 
 To use the VirusTotal API wrapper import VirusTotalApi class from threat_intel.virustotal module:
 
-    >>> from threat_intel.virustotal import VirusTotalApi
+    >>> from threat_intel import VirusTotalApi
 
 To initialize the API wrapper you need the API key:
 
@@ -372,7 +372,7 @@ ShadowServer provides and API that allows to test the hashes against a list of k
 
 To use the ShadowServer API wrapper import ShadowServerApi class from threat_intel.shadowserver module:
 
-    >>> from threat_intel.shadowserver import ShadowServerApi
+    >>> from threat_intel import ShadowServerApi
 
 To use the API wrapper simply call the ShadowServerApi initializer:
 
@@ -393,5 +393,10 @@ want to test:
     >>> ss.get_bin_test(file_hashes)
 
 """
+from exceptions import InvalidRequestError
 
-__all__ = ['exceptions', 'opendns', 'shadowserver', 'virustotal']
+from opendns import InvestigateApi
+from shadowserver import ShadowServerApi
+from virustotal import VirusTotalApi
+
+__all__ = ['InvalidRequestError', 'InvestigateApi', 'ShadowServerApi', 'VirusTotalApi']

--- a/threat_intel/util/http.py
+++ b/threat_intel/util/http.py
@@ -4,6 +4,7 @@
 #
 # RateLimiter helps to only make a certain number of calls per second.
 # MultiRequest wraps grequests and issues multiple requests at once with an easy to use interface.
+# SSLAdapter helps force use of the highest possible version of TLS.
 #
 import ssl
 import time


### PR DESCRIPTION
This is a fix for https://github.com/Yelp/threat_intel/issues/35

**Use Best SSL/TLS**
The basic trick is to tell `requests` and `grequests` to use `ssl.PROTOCOL_SSLv23` which actually translates to *whatever is best*. Check out the docs for [`ssl.wrap_socket`](https://docs.python.org/2/library/ssl.html#socket-creation) to see what this constant really means.

**Fix Manual Virtualenv Creation**
`$ pip install -r requirements-dev.txt` wasn't forcing the requirements in `requirements.txt` to be pip installed. 

**Cleanup `__all__`**
```python
from threat_intel import VirusTotalApi
```
is nicer than
```python
from threat_intel.virustotal import VirusTotalApi
```

**Version Bump**
I wanna ensure packages that depend on this can pin to this version.

**Testing**
I tested all 3 apis manually to ensure there were no OpenSSL errors.
I also tested the change to `__all__` and even looked at the `help` for the doc changes.



