### PR TITLE
Adding optional parameter specifying whether to write out the content…

### DIFF
--- a/tests/util/api_cache_test.py
+++ b/tests/util/api_cache_test.py
@@ -21,7 +21,7 @@ def assert_cache_written(mock_write, patched_open):
 
 
 def assert_cache_not_written(mock_write):
-    T.assert_false(mock_write.called)
+    T.assert_falsey(mock_write.called)
     return None
 
 

--- a/threat_intel/opendns.py
+++ b/threat_intel/opendns.py
@@ -47,12 +47,12 @@ class InvestigateApi(object):
 
     BASE_URL = u'https://investigate.api.opendns.com/'
 
-    def __init__(self, api_key, cache_file_name=None):
+    def __init__(self, api_key, cache_file_name=None, update_cache=True):
         auth_header = {'Authorization': 'Bearer {0}'.format(api_key)}
         self._requests = MultiRequest(default_headers=auth_header, max_requests=12, rate_limit=30)
 
         # Create an ApiCache if instructed to
-        self._cache = ApiCache(cache_file_name) if cache_file_name else None
+        self._cache = ApiCache(cache_file_name, update_cache) if cache_file_name else None
 
     @classmethod
     def _to_url(cls, url_path):

--- a/threat_intel/shadowserver.py
+++ b/threat_intel/shadowserver.py
@@ -11,11 +11,13 @@ from threat_intel.util.http import MultiRequest
 class ShadowServerApi(object):
     BINTEST_URL = u'http://bin-test.shadowserver.org/api'
 
-    def __init__(self, cache_file_name=None):
+    def __init__(self, cache_file_name=None, update_cache=True):
         """Establishes basic HTTP params and loads a cache.
 
         Args:
             cache_file_name: String file name of cache.
+            update_cache: Determines whether cache should be written out back to the disk when closing it.
+                          Default is `True`.
         """
 
         # TODO - lookup request rate limit
@@ -23,7 +25,7 @@ class ShadowServerApi(object):
         self._requests = MultiRequest(max_requests=2, req_timeout=90.0)
 
         # Create an ApiCache if instructed to
-        self._cache = ApiCache(cache_file_name) if cache_file_name else None
+        self._cache = ApiCache(cache_file_name, update_cache) if cache_file_name else None
 
     @MultiRequest.error_handling
     def get_bin_test(self, hashes):

--- a/threat_intel/util/api_cache.py
+++ b/threat_intel/util/api_cache.py
@@ -10,14 +10,17 @@ class ApiCache(object):
 
     """creates an on disk cache of API call results."""
 
-    def __init__(self, cache_file_name):
+    def __init__(self, cache_file_name, update_cache=True):
         """Opens the cache file and reads previous results.
 
         Args:
                 cache_file_name: string file name
+                update_cache: Specifies whether ApiCache should write out the
+                              cache file when closing it
         """
         self._cache_file_name = cache_file_name
         self._cache = self._read_cache_from_file()
+        self._update_cache = update_cache
 
     def __del__(self):
         """Ensures cache is persisted to disk before object is destroyed.
@@ -28,9 +31,12 @@ class ApiCache(object):
         self.close()
 
     def close(self):
-        """Write the contents of the cache to disk and clear the in memory cache."""
+        """Write the contents of the cache to disk (only if `update_cache`
+        parameter during the object initialization was not set to `False`) and
+        clear the in memory cache."""
         if self._cache:
-            self._write_cache_to_file()
+            if self._update_cache:
+                self._write_cache_to_file()
             self._cache = None
 
     def _write_cache_to_file(self):

--- a/threat_intel/virustotal.py
+++ b/threat_intel/virustotal.py
@@ -9,7 +9,7 @@ from threat_intel.util.http import MultiRequest
 class VirusTotalApi(object):
     BASE_DOMAIN = u'https://www.virustotal.com/vtapi/v2/'
 
-    def __init__(self, api_key, resources_per_req=25, cache_file_name=None):
+    def __init__(self, api_key, resources_per_req=25, cache_file_name=None, update_cache=True):
         """Establishes basic HTTP params and loads a cache.
 
         Args:
@@ -17,13 +17,15 @@ class VirusTotalApi(object):
             resources_per_req: Maximum number of resources (hashes, URLs)
                 to be send in a single request
             cache_file_name: String file name of cache.
+            update_cache: Determines whether cache should be written out back to the disk when closing it.
+                          Default is `True`.
         """
         self._api_key = api_key
         self._resources_per_req = resources_per_req
         self._requests = MultiRequest()
 
         # Create an ApiCache if instructed to
-        self._cache = ApiCache(cache_file_name) if cache_file_name else None
+        self._cache = ApiCache(cache_file_name, update_cache) if cache_file_name else None
 
     @MultiRequest.error_handling
     def get_file_reports(self, resources):


### PR DESCRIPTION
…s of the cache back to the disk when closing the cache file

I have added an optional `update_cache` parameter which should determine whether to write out the content of the cache back to the disk.

It fixes #41.