### PR TITLE
Upgrade simplejson

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 grequests==0.2.0
 # Make sure to install the optional security components for requests
-requests[security]==2.7.0
-simplejson==3.6.5
+requests[security]==2.8.1
+simplejson==3.7.3

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ setup(
     description="Collection of the API calls for various threat intel feeds.",
     packages=find_packages(),
     install_requires=[
-        "requests[security]==2.7.0",
-        "grequests==0.2.0",
-        "simplejson==3.6.5"
+        "requests[security]",
+        "grequests",
+        "simplejson"
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="threat_intel",
-    version='0.1.9',
+    version='0.1.10',
     provides=['threat_intel'],
     author="Yelp Security",
     url='https://github.com/Yelp/threat_intel',


### PR DESCRIPTION
`simplejson` version in https://github.com/Yelp/osxcollector_output_filters was conflicting with the one in Threat Intel so it is actually making sense to bump it here as well for the sake of consistency.