### PR TITLE
Better HTTP error handling

### DIFF
--- a/tests/util/http_test.py
+++ b/tests/util/http_test.py
@@ -11,59 +11,55 @@ from threat_intel.util.http import MultiRequest
 
 class MultiRequestTest(T.TestCase):
 
-    def test_multi_get_access_forbidden(self):
-        """Tests the exception handling in the cases when a request returns '403 Forbidden'."""
-        # mock responses
+    def mock_responses(self):
+        """Creates a bunch of response mocks, with the '200 OK' HTTP status code."""
         responses = [MagicMock()] * 20
         for response in responses:
             response.status_code = 200
-        responses[13].status_code = 403
+        return responses
 
+    def patch_grequests_map_and_assert_raises_invalid_request_error(self, responses, exception_test):
+        """Patches a call to `grequest.map` returning the list of `responses`.
+        Verifies that the exception of type `InvalidRequestError` was raised and that it passes the `exception_test`.
+
+        Returns:
+            Patched `grequests.map` method
+        """
         query_params = [{'Hugh Glass': 'Leonardo DiCaprio'}] * 20
-
-        says_access_forbidden = lambda e: T.assert_equal(str(e), 'Access forbidden')
         with nested(
             patch('grequests.map', return_value=responses),
-            T.assert_raises_such_that(InvalidRequestError, says_access_forbidden)
-        ):
+            T.assert_raises_such_that(InvalidRequestError, exception_test)
+        ) as (patched_grequests_map, __):
             MultiRequest().multi_get('example.com', query_params)
+        return patched_grequests_map
+
+    def test_multi_get_access_forbidden(self):
+        """Tests the exception handling in the cases when a request returns '403 Forbidden'."""
+        responses = self.mock_responses()
+        responses[13].status_code = 403
+
+        says_access_forbidden = lambda e: T.assert_equal(str(e), 'Access forbidden')
+        self.patch_grequests_map_and_assert_raises_invalid_request_error(responses, says_access_forbidden)
 
     def test_multi_get_max_retries(self):
         """Tests the exception handling in case the number of the maximum retries is reached, due to the empty responses."""
-        # mock responses
-        responses = [MagicMock()] * 10
-        for response in responses:
-            response.status_code = 200
+        responses = self.mock_responses()
         responses[7] = None
 
-        query_params = [{'John Fitzgerald': 'Tom Hardy'}] * 10
-
         says_max_retries = lambda e: T.assert_equal(str(e), 'Unable to complete batch of requests within 10 retries')
-        with nested(
-            patch('grequests.map', return_value=responses),
-            T.assert_raises_such_that(InvalidRequestError, says_max_retries)
-        ) as (patched_grequests_map, __):
-            MultiRequest().multi_get('example.com', query_params)
+        patched_grequests_map = self.patch_grequests_map_and_assert_raises_invalid_request_error(responses, says_max_retries)
 
+        # the default number of retries is 10
         T.assert_equal(10, patched_grequests_map.call_count)
 
     def test_multi_get_expected_json_response(self):
         """Tests the exception handling in the cases when the response was supposed to return JSON but did not."""
-        # mock responses
-        responses = [MagicMock()] * 5
-        for response in responses:
-            response.status_code = 200
+        responses = self.mock_responses()
 
         # mock the exception raised in case response cannot be converted to JSON
         # based on: http://docs.python-requests.org/en/master/user/quickstart/#json-response-content
         responses[3].json.side_effect = ValueError('No JSON object could be decoded')
         responses[3].request.url = 'example.com/movie'
 
-        query_params = [{'Andrew Henry': 'Domhnall Gleeson'}] * 5
-
         says_expected_json_response = lambda e: T.assert_equal(str(e), 'Expected JSON response from: example.com/movie')
-        with nested(
-            patch('grequests.map', return_value=responses),
-            T.assert_raises_such_that(InvalidRequestError, says_expected_json_response)
-        ):
-            MultiRequest().multi_get('example.com', query_params)
+        self.patch_grequests_map_and_assert_raises_invalid_request_error(responses, says_expected_json_response)

--- a/tests/util/http_test.py
+++ b/tests/util/http_test.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from contextlib import nested
+
+import testify as T
+from mock import MagicMock
+from mock import patch
+
+from threat_intel.exceptions import InvalidRequestError
+from threat_intel.util.http import MultiRequest
+
+
+class MultiRequestTest(T.TestCase):
+
+    def test_multi_get_access_forbidden(self):
+        """Tests the exception handling in the cases when a request returns '403 Forbidden'."""
+
+        # mock responses
+        responses = [MagicMock()] * 20
+        for response in responses:
+            response.status_code = 200
+        responses[13].status_code = 403
+
+        query_params = [{'Hugh Glass': 'Leonardo DiCaprio'}] * 20
+
+        says_access_forbidden = lambda e: T.assert_equal(str(e), 'Access forbidden')
+        with nested(
+            patch('grequests.map', return_value=responses),
+            T.assert_raises_such_that(InvalidRequestError, says_access_forbidden)
+        ):
+            MultiRequest().multi_get('example.com', query_params)

--- a/tests/util/http_test.py
+++ b/tests/util/http_test.py
@@ -13,7 +13,6 @@ class MultiRequestTest(T.TestCase):
 
     def test_multi_get_access_forbidden(self):
         """Tests the exception handling in the cases when a request returns '403 Forbidden'."""
-
         # mock responses
         responses = [MagicMock()] * 20
         for response in responses:
@@ -28,3 +27,22 @@ class MultiRequestTest(T.TestCase):
             T.assert_raises_such_that(InvalidRequestError, says_access_forbidden)
         ):
             MultiRequest().multi_get('example.com', query_params)
+
+    def test_multi_get_max_retries(self):
+        """Tests the exception handling in case the number of the maximum retries is reached, due to the empty responses."""
+        # mock responses
+        responses = [MagicMock()] * 10
+        for response in responses:
+            response.status_code = 200
+        responses[7] = None
+
+        query_params = [{'John Fitzgerald': 'Tom Hardy'}] * 10
+
+        says_max_retries = lambda e: T.assert_equal(str(e), 'Unable to complete batch of requests within 10 retries')
+        with nested(
+            patch('grequests.map', return_value=responses),
+            T.assert_raises_such_that(InvalidRequestError, says_max_retries)
+        ) as (patched_grequests_map, __):
+            MultiRequest().multi_get('example.com', query_params)
+
+        T.assert_equal(10, patched_grequests_map.call_count)

--- a/threat_intel/util/http.py
+++ b/threat_intel/util/http.py
@@ -255,16 +255,15 @@ class MultiRequest(object):
             try:
                 responses = grequests.map(requests)
                 valid_responses = [response for response in responses if response]
-                failed_auth_responses = [response for response in responses if response.status_code == 403]
 
-                if failed_auth_responses:
-                    raise ConnectionError('Credentials not authorized to access URL')
+                if any(response is not None and response.status_code == 403 for response in responses):
+                    raise InvalidRequestError('Access forbidden')
 
                 if len(valid_responses) != len(requests):
                     continue
                 else:
                     break
-            except ConnectionError:
+            except InvalidRequestError:
                 raise
             except:
                 pass

--- a/threat_intel/util/http.py
+++ b/threat_intel/util/http.py
@@ -11,9 +11,9 @@ import time
 from collections import namedtuple
 
 import grequests
+from requests import ConnectionError
 from requests import Session
 from requests.adapters import HTTPAdapter
-from requests import ConnectionError
 
 from threat_intel.exceptions import InvalidRequestError
 from threat_intel.util.error_messages import write_error_message
@@ -239,31 +239,6 @@ class MultiRequest(object):
             data = data * max_count
 
         return zip(urls, query_params, data)
-
-    class _FakeResponse(object):
-
-        """_FakeResponse looks enough like a response from grequests to handle when grequests has no response.
-
-        Attributes:
-            request - The request object
-            status_code - The HTTP response status code
-        """
-
-        def __init__(self, request, status_code):
-            self._request = request
-            self._status_code = status_code
-
-        @property
-        def request(self):
-            return self._request
-
-        @property
-        def status_code(self):
-            return self._status_code
-
-        def json(self):
-            """Convert the response body to a dict."""
-            return {}
 
     def _wait_for_response(self, requests, to_json):
         """Issue a batch of requests and wait for the responses.

--- a/threat_intel/util/http.py
+++ b/threat_intel/util/http.py
@@ -292,7 +292,10 @@ class MultiRequest(object):
                 write_error_message('url[{0}] status_code[{1}]'.format(response.request.url, response.status_code))
 
             if to_json:
-                all_responses.append(response.json())
+                try:
+                    all_responses.append(response.json())
+                except ValueError:
+                    raise InvalidRequestError('Expected JSON response from: {0}'.format(response.request.url))
             else:
                 all_responses.append(response)
 


### PR DESCRIPTION
It seems that the current way of handling erroneous situations was a bit off at the times.
E.g. check for the HTTP status code 403 inside the retry loop in the `_wait_for_response` method would fail if the response was empty, because there would be an exception caused by trying to access `status_code` member, which `None` doesn't have.

Also, the check whether the `self._max_retry` number of tries was reached was wrong as it should have compared to the last retry count incremented by 1. Python `range` method does return the values from 0 up to `self._max_retry - 1`, so the `retry` variable actually would have never been equal to `self._max_retry`.

I have also added an error handling for the cases when the response cannot be converted to JSON although it was expected to be in the JSON format. 