### PR TITLE
Added a check for None in the condition

### DIFF
--- a/threat_intel/shadowserver.py
+++ b/threat_intel/shadowserver.py
@@ -52,7 +52,7 @@ class ShadowServerApi(object):
 
         responses = self._requests.multi_post(self.BINTEST_URL, data=hash_chunks, to_json=False, send_as_file=True)
         for response in responses:
-            if 200 == response.status_code:
+            if response is not None and 200 == response.status_code:
                 response_lines = response.text.split('\n')
                 for line in response_lines:
                     # Set an initial val.


### PR DESCRIPTION
Shadowserver API seems to be having some troubles today and sends 500 all around.
Unfortunately the test for the response `200 OK` in `threat_intel/shadowserver.py` was not checking whether the response is `None`, which would be the case for the responses that are still invalid after several tries.

This change should fix the problem by ensuring that `response is not None`.