### PR TITLE
Add req_timeout as default arg to all provider APIs

### DIFF
--- a/threat_intel/opendns.py
+++ b/threat_intel/opendns.py
@@ -57,9 +57,9 @@ class InvestigateApi(object):
     # TODO: consider moving this to a config file
     MAX_DOMAINS_IN_POST = 1000
 
-    def __init__(self, api_key, cache_file_name=None, update_cache=True):
+    def __init__(self, api_key, cache_file_name=None, update_cache=True, req_timeout=None):
         auth_header = {'Authorization': 'Bearer {0}'.format(api_key)}
-        self._requests = MultiRequest(default_headers=auth_header, max_requests=12, rate_limit=30)
+        self._requests = MultiRequest(default_headers=auth_header, max_requests=12, rate_limit=30, req_timeout=req_timeout)
 
         # Create an ApiCache if instructed to
         self._cache = ApiCache(cache_file_name, update_cache) if cache_file_name else None

--- a/threat_intel/shadowserver.py
+++ b/threat_intel/shadowserver.py
@@ -11,18 +11,20 @@ from threat_intel.util.http import MultiRequest
 class ShadowServerApi(object):
     BINTEST_URL = u'http://bin-test.shadowserver.org/api'
 
-    def __init__(self, cache_file_name=None, update_cache=True):
+    def __init__(self, cache_file_name=None, update_cache=True, req_timeout=90.0):
         """Establishes basic HTTP params and loads a cache.
 
         Args:
             cache_file_name: String file name of cache.
             update_cache: Determines whether cache should be written out back to the disk when closing it.
                           Default is `True`.
+            req_timeout: Maximum number of seconds to wait without reading a response byte before deciding an error has occurred.
+                         Default is 90.0 seconds.
         """
 
         # TODO - lookup request rate limit
         # By observation, ShadowServer can be quite slow, so give it 90 seconds before it times out.
-        self._requests = MultiRequest(max_requests=2, req_timeout=90.0)
+        self._requests = MultiRequest(max_requests=2, req_timeout=req_timeout)
 
         # Create an ApiCache if instructed to
         self._cache = ApiCache(cache_file_name, update_cache) if cache_file_name else None

--- a/threat_intel/util/http.py
+++ b/threat_intel/util/http.py
@@ -113,7 +113,7 @@ class MultiRequest(object):
     _VERB_GET = 'GET'
     _VERB_POST = 'POST'
 
-    def __init__(self, default_headers=None, max_requests=20, rate_limit=0, req_timeout=25.0, max_retry=10):
+    def __init__(self, default_headers=None, max_requests=20, rate_limit=0, req_timeout=None, max_retry=10):
         """Create the MultiRequest.
 
         Args:
@@ -124,7 +124,7 @@ class MultiRequest(object):
         """
         self._default_headers = default_headers
         self._max_requests = max_requests
-        self._req_timeout = req_timeout
+        self._req_timeout = req_timeout or 25.0
         self._max_retry = max_retry
         self._rate_limiter = RateLimiter(rate_limit) if rate_limit else None
         self._session = Session()

--- a/threat_intel/virustotal.py
+++ b/threat_intel/virustotal.py
@@ -9,7 +9,7 @@ from threat_intel.util.http import MultiRequest
 class VirusTotalApi(object):
     BASE_DOMAIN = u'https://www.virustotal.com/vtapi/v2/'
 
-    def __init__(self, api_key, resources_per_req=25, cache_file_name=None, update_cache=True):
+    def __init__(self, api_key, resources_per_req=25, cache_file_name=None, update_cache=True, req_timeout=None):
         """Establishes basic HTTP params and loads a cache.
 
         Args:
@@ -19,10 +19,12 @@ class VirusTotalApi(object):
             cache_file_name: String file name of cache.
             update_cache: Determines whether cache should be written out back to the disk when closing it.
                           Default is `True`.
+            req_timeout: Maximum number of seconds to wait without reading a response byte before deciding an error has occurred.
+                         Default is None.
         """
         self._api_key = api_key
         self._resources_per_req = resources_per_req
-        self._requests = MultiRequest()
+        self._requests = MultiRequest(req_timeout=req_timeout)
 
         # Create an ApiCache if instructed to
         self._cache = ApiCache(cache_file_name, update_cache) if cache_file_name else None


### PR DESCRIPTION
This change would allow a user to define the request timeout for the OpenDNS, VirusTotal, and ShadowServer APIs.