### PR TITLE
Added integration with OpenDNS Investigate endpoint for file hashes

### DIFF
--- a/tests/opendns_test.py
+++ b/tests/opendns_test.py
@@ -265,3 +265,11 @@ class InvestigateApiTest(T.TestCase):
                                 expected_query_params='domain',
                                 api_response={},
                                 expected_result={})
+
+    def test_sample(self):
+        self._test_api_call_get(call=self.opendns.sample,
+                                endpoint=u'sample/{0}',
+                                request=['0492d93195451e41f568f68e7704eb0812bc2b19'],
+                                expected_query_params='0492d93195451e41f568f68e7704eb0812bc2b19',
+                                api_response={},
+                                expected_result={})

--- a/threat_intel/opendns.py
+++ b/threat_intel/opendns.py
@@ -280,6 +280,19 @@ class InvestigateApi(object):
         fmt_url_path = u'ips/{0}/latest_domains'
         return self._multi_get(api_name, fmt_url_path, ips)
 
+    def sample(self, hashes):
+        """Get the information about a sample based on its hash.
+
+        Args:
+            hashes: an enumerable of strings as hashes
+        Returns:
+            An enumerable of arrays which contains the information
+            about the original samples
+        """
+        api_name = 'opendns-sample'
+        fmt_url_path = u'sample/{0}'
+        return self._multi_get(api_name, fmt_url_path, hashes)
+
 
 class ResponseError(Exception):
 


### PR DESCRIPTION
OpenDNS added `sample` API endpoint for Cisco's Threat Grid intel about file hashes.