### PR TITLE
Issue 49 : Fix discarding of session connections due to connection pool being filled

### DIFF
--- a/threat_intel/util/http.py
+++ b/threat_intel/util/http.py
@@ -12,7 +12,6 @@ import ssl
 import time
 from collections import namedtuple
 from collections import OrderedDict
-import pdb
 
 import grequests
 from requests import Session
@@ -130,7 +129,6 @@ class MultiRequest(object):
         self._max_retry = max_retry
         self._rate_limiter = RateLimiter(rate_limit) if rate_limit else None
         self._session = Session()
-        pdb.set_trace()
         self._session.mount('https://', SSLAdapter(pool_maxsize=max(10, max_requests)))
 
     def multi_get(self, urls, query_params=None, to_json=True):

--- a/threat_intel/util/http.py
+++ b/threat_intel/util/http.py
@@ -12,6 +12,7 @@ import ssl
 import time
 from collections import namedtuple
 from collections import OrderedDict
+import pdb
 
 import grequests
 from requests import Session
@@ -129,7 +130,8 @@ class MultiRequest(object):
         self._max_retry = max_retry
         self._rate_limiter = RateLimiter(rate_limit) if rate_limit else None
         self._session = Session()
-        self._session.mount('https://', SSLAdapter())
+        pdb.set_trace()
+        self._session.mount('https://', SSLAdapter(pool_maxsize=max(10, max_requests)))
 
     def multi_get(self, urls, query_params=None, to_json=True):
         """Issue multiple GET requests.


### PR DESCRIPTION
This fix addresses the previous warnings generated due to pool sizes of the underlying SSL adapter being used to make threat intel API requests going over the maximum threshold. The fix was as simple as configuring the adapter to utilize a maximum pool size corresponding to the maximum of 10 (HTTP Adapter's default pool size) and the batch size specified for async `grequests`. 